### PR TITLE
feat: add a new parameter to the api and some other changes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { createCors } from 'itty-cors'
 
 import pkg from '../package.json'
 import { DiagramRoute, RenderRoute } from './routes/Diagram'
-import { ShortLinkRoute, debugCreateLink } from './routes/Shorten'
+import { ShortLinkRoute, DiagramLinkRoute, debugCreateLink } from './routes/Shorten'
 import { logoSvg } from './logo'
 import { html as privacyPageHtml } from './privacy-page'
 
@@ -58,6 +58,7 @@ router.original.get('/legal', () =>
 )
 
 router.original.get('/s/:id', ShortLinkRoute)
+router.original.get('/d/:id', DiagramLinkRoute)
 router.original.get('/.well-known/ai-plugin.json', ManifestRoute);
 router.original.get('/logo.svg', (request: Request, env: Env) => {
   console.log('logo')

--- a/src/index.ts
+++ b/src/index.ts
@@ -248,7 +248,7 @@ Your call to the api:
 Interpreting the API response:
 - When you get the response it will include an image url, you should render it inline using ![alt text](image) syntax.
 - Suggest to the user that they can edit the diagram with followup requests in chat.
-- You will also get a link as editDiagramOnline to edit the diagram, you should render it inline using [link text](editDiagramOnline) syntax. Include the whole suggestion to edit the diagram as part of the link. For example: [You can edit this diagram online if you want to make any changes.](editDiagramOnline). If the link value is unknown then say: Please note that the link to edit this diagram online is not implemented yet.
+- If you get a link as editDiagramOnline to edit the diagram, you should render it inline using [link text](editDiagramOnline) syntax. Include the whole suggestion to edit the diagram as part of the link. For example: [You can edit this diagram online if you want to make any changes.](editDiagramOnline). If you dont get the editDiagramOnline link then say: Please note that the link to edit this diagram online is not implemented yet.
 - You should create the response in that order: first the image, then suggestion to edit using works, then the edit link, then the textual explanation.
 
 Tips:

--- a/src/routes/Diagram.ts
+++ b/src/routes/Diagram.ts
@@ -34,6 +34,15 @@ export class DiagramRoute extends OpenAPIRoute {
           )
         })
       ),
+      diagramType: Query(
+        new Str({
+          description: "Type of the diagram",
+          example: "graph",
+        }),
+        {
+          required: true,
+        }
+      ),
       topic: Query(
         new Str({
           description: "Topic of the diagram",
@@ -80,6 +89,7 @@ export class DiagramRoute extends OpenAPIRoute {
     const diagramLanguage = new URL(request.url).searchParams.get("diagramLanguage") as DiagramLanguage
     const diagramParam = new URL(request.url).searchParams.get("diagram");
     const topic  = new URL(request.url).searchParams.get("topic");
+    const diagramType  = new URL(request.url).searchParams.get("diagramType");
     console.log('diagram', diagramParam)
     console.log('topic', topic)
 
@@ -113,7 +123,7 @@ export class DiagramRoute extends OpenAPIRoute {
       'diagram_language': diagramLanguage,
 
       // Mixpanel truncates all strings https://developer.mixpanel.com/reference/import-events#common-issues
-      'diagram_type': diagram.type,
+      'diagram_type': diagramType,
       'diagram': diagramParam.length > 255 ? diagramParam.substring(0, 200) + " -- truncated" : diagramParam,
 
       'topic': topic,
@@ -132,7 +142,7 @@ export class DiagramRoute extends OpenAPIRoute {
       'diagram_language': diagramLanguage,
       'diagram_syntax_is_valid': diagram.isValid,
 
-      'diagram_type': diagram.type,
+      'diagram_type': diagramType,
       'diagram_url': shortenedURL,
       'edit_diagram_url': shortenedEditDiagramURL,
 

--- a/src/routes/Diagram.ts
+++ b/src/routes/Diagram.ts
@@ -33,7 +33,16 @@ export class DiagramRoute extends OpenAPIRoute {
             diagramLanguages.map(language => [language, language])
           )
         })
-      )
+      ),
+      topic: Query(
+        new Str({
+          description: "Topic of the diagram",
+          example: "Software Architecture",
+        }),
+        {
+          required: true,
+        }
+      ),
     },
     responses: {
       "200": {
@@ -70,7 +79,9 @@ export class DiagramRoute extends OpenAPIRoute {
     // Extract data from request
     const diagramLanguage = new URL(request.url).searchParams.get("diagramLanguage") as DiagramLanguage
     const diagramParam = new URL(request.url).searchParams.get("diagram");
+    const topic  = new URL(request.url).searchParams.get("topic");
     console.log('diagram', diagramParam)
+    console.log('topic', topic)
 
     const diagram = await diagramDetails(diagramParam, diagramLanguage)
 
@@ -104,6 +115,8 @@ export class DiagramRoute extends OpenAPIRoute {
       // Mixpanel truncates all strings https://developer.mixpanel.com/reference/import-events#common-issues
       'diagram_type': diagram.type,
       'diagram': diagramParam.length > 255 ? diagramParam.substring(0, 200) + " -- truncated" : diagramParam,
+
+      'topic': topic,
     })
 
     const slug = await saveShortLink(env.SHORTEN, diagram.diagramSVG)
@@ -122,6 +135,8 @@ export class DiagramRoute extends OpenAPIRoute {
       'diagram_type': diagram.type,
       'diagram_url': shortenedURL,
       'edit_diagram_url': shortenedEditDiagramURL,
+
+      'topic': topic,
     })
 
     const responseBody =

--- a/src/routes/Diagram.ts
+++ b/src/routes/Diagram.ts
@@ -69,6 +69,7 @@ export class DiagramRoute extends OpenAPIRoute {
               editDiagramOnline: new Str({
                 description:
                   "URL to the editor where the diagram can be edited",
+                required: false,
               }),
               contributeToOpenSourceProject: new Str({
                 description: "GitHub URL to the open source project for this project",
@@ -133,7 +134,7 @@ export class DiagramRoute extends OpenAPIRoute {
     const diagramURL = `${BASE_URL}/d/${slug}`
 
     const editorSlug = diagram.editorLink ? await saveShortLink(env.SHORTEN, diagram.editorLink) : "";
-    const shortenedEditDiagramURL = diagram.editorLink ? `${BASE_URL}/s/${editorSlug}` : "unknown"
+    const shortenedEditDiagramURL = diagram.editorLink ? `${BASE_URL}/s/${editorSlug}` : null
 
     console.log({ diagramURL })
     console.log('diagram svg', diagram.diagramSVG)
@@ -144,23 +145,18 @@ export class DiagramRoute extends OpenAPIRoute {
 
       'diagram_type': diagramType,
       'diagram_url': diagramURL,
-      'edit_diagram_url': shortenedEditDiagramURL,
+      'edit_diagram_url': shortenedEditDiagramURL ?? "not implemented yet",
 
       'topic': topic,
     })
 
     const responseBody =
       {
-        results: diagram.isValid ? [
+        results:  [
           {
-            image: diagramURL,
-            editDiagramOnline: shortenedEditDiagramURL,
-            contributeToOpenSourceProject: 'https://github.com/bra1nDump/show-me-chatgpt-plugin/issues'
-          }
-        ] : [
-          {
-            errorMessage: "GPT created an invalid diagram, you can try again or edit it online",
-            editDiagramOnline: shortenedEditDiagramURL,
+            ...diagram.isValid && { image: diagramURL },
+            ...!diagram.isValid && { errorMessage: "GPT created an invalid diagram, you can try again or edit it online" },
+            ...shortenedEditDiagramURL && { editDiagramOnline: shortenedEditDiagramURL },
             contributeToOpenSourceProject: 'https://github.com/bra1nDump/show-me-chatgpt-plugin/issues'
           }
         ]

--- a/src/routes/Diagram.ts
+++ b/src/routes/Diagram.ts
@@ -130,12 +130,12 @@ export class DiagramRoute extends OpenAPIRoute {
     })
 
     const slug = await saveShortLink(env.SHORTEN, diagram.diagramSVG)
-    const shortenedURL = `${BASE_URL}/s/${slug}`
+    const diagramURL = `${BASE_URL}/d/${slug}`
 
     const editorSlug = diagram.editorLink ? await saveShortLink(env.SHORTEN, diagram.editorLink) : "";
     const shortenedEditDiagramURL = diagram.editorLink ? `${BASE_URL}/s/${editorSlug}` : "unknown"
 
-    console.log({ shortenedURL })
+    console.log({ diagramURL })
     console.log('diagram svg', diagram.diagramSVG)
 
     await track('render_complete', {
@@ -143,7 +143,7 @@ export class DiagramRoute extends OpenAPIRoute {
       'diagram_syntax_is_valid': diagram.isValid,
 
       'diagram_type': diagramType,
-      'diagram_url': shortenedURL,
+      'diagram_url': diagramURL,
       'edit_diagram_url': shortenedEditDiagramURL,
 
       'topic': topic,
@@ -153,7 +153,7 @@ export class DiagramRoute extends OpenAPIRoute {
       {
         results: diagram.isValid ? [
           {
-            image: shortenedURL,
+            image: diagramURL,
             editDiagramOnline: shortenedEditDiagramURL,
             contributeToOpenSourceProject: 'https://github.com/bra1nDump/show-me-chatgpt-plugin/issues'
           }

--- a/src/routes/Shorten.ts
+++ b/src/routes/Shorten.ts
@@ -16,7 +16,7 @@ export async function saveShortLink(
   return slug
 }
 
-export async function ShortLinkRoute(request, env) {
+export async function DiagramLinkRoute(request, env) {
   const slug = request.params.id
   if (!slug) {
     return new Response('404 Not Found...', { status: 200 })
@@ -29,6 +29,25 @@ export async function ShortLinkRoute(request, env) {
   return new Response(imageSVG, {
     headers: {
       'content-type': 'image/svg+xml'
+    }
+  })
+}
+
+export async function ShortLinkRoute(request, env) {
+  const slug = request.params.id
+  if (!slug) {
+    return new Response('404 Not Found...', { status: 200 })
+  }
+  const targetUrl = await env.SHORTEN.get(slug)
+  if (!targetUrl) {
+    return new Response('404 Not Found...', { status: 200 })
+  }
+
+  return new Response(null, {
+    status: 301,
+    statusText: 'Moved Permanently',
+    headers: {
+      Location: targetUrl
     }
   })
 }

--- a/src/routes/diagrams/index.ts
+++ b/src/routes/diagrams/index.ts
@@ -1,9 +1,8 @@
 import { compressAndEncodeBase64, DiagramLanguage, getSVG } from "./utils";
-import { mermaidDiagramType, mermaidEditorLink, mermaidFormat } from "./mermaid";
+import { mermaidEditorLink, mermaidFormat } from "./mermaid";
 import { plantumlEditorLink } from "./plantuml";
 
 type DiagramDetails = {
-  type: string,
   editorLink: string,
   isValid: boolean,
   diagramSVG: string,
@@ -11,19 +10,16 @@ type DiagramDetails = {
 
 export async function diagramDetails(diagram: string, diagramLanguage: DiagramLanguage): Promise<DiagramDetails> {
   type DiagramFunctions = {
-    type: ((diagram: string) => string) | null,
     format: ((diagram: string) => string) | null,
     editorLink: (diagram: string) => string | null
   };
 
   const getDiagramFunctions: Partial<Record<DiagramLanguage, DiagramFunctions>> = {
     "mermaid": {
-      type: mermaidDiagramType,
       format: mermaidFormat,
       editorLink: mermaidEditorLink,
     },
     "plantuml": {
-      type: null,
       format: null,
       editorLink: plantumlEditorLink,
     },
@@ -31,7 +27,6 @@ export async function diagramDetails(diagram: string, diagramLanguage: DiagramLa
   }
 
   const defaultDiagramFunctions: DiagramFunctions = {
-    type: null,
     format: null,
     editorLink: null,
   }
@@ -48,7 +43,6 @@ export async function diagramDetails(diagram: string, diagramLanguage: DiagramLa
   const diagramSVG = await getSVG(imageUrl);
 
   return {
-    type: diagramFunctions.type?.(formattedDiagram) ?? "unknown",
     editorLink: diagramFunctions.editorLink?.(formattedDiagram) ?? "",
     isValid: Boolean(diagramSVG),
     diagramSVG

--- a/src/routes/diagrams/mermaid.ts
+++ b/src/routes/diagrams/mermaid.ts
@@ -23,10 +23,6 @@ export function mermaidFormat(diagram: string): string {
   return mermaidNoPluses
 }
 
-export function mermaidDiagramType(diagram: string): string {
-  return diagram.split('\n')[0]
-}
-
 export function mermaidEditorLink(code: string): string {
   const mermaidEditorJson = {
     code,


### PR DESCRIPTION
# Description of commits 
## feat: add a new parameter to the API - topic
Solves #6 

Example:
![image](https://github.com/bra1nDump/show-me-chatgpt-plugin/assets/21105282/59ed692a-d06a-4206-b1eb-168a742f8b1a)


## feat: add a new parameter to the API - diagramType:
Helpful to recognize the diagram type instead of getting it in the backend like the mermaidDiagramType function, This will reduce the effort to recognize each diagram type of each language. 
 ![image](https://github.com/bra1nDump/show-me-chatgpt-plugin/assets/21105282/5d7a10ad-6511-42f5-a99f-12b2fe40176a)

## fix: editDiagramOnline link does not work
When I solved  #1 I did not notice that I broke the edit diagram link. When it is opened shows:
![image](https://github.com/bra1nDump/show-me-chatgpt-plugin/assets/21105282/7d7d7e2b-5ba4-4e47-80ff-ac6634b6e78f)

## fix: sometimes chatgpt confuses the answer of editDiagramOnline
Sometimes the plugin shows both cases of when editDiagramOnline is available or not
![image](https://github.com/bra1nDump/show-me-chatgpt-plugin/assets/21105282/db57e7ef-1914-4190-ad74-b41e111d6791)

